### PR TITLE
Update cors url

### DIFF
--- a/scripts/components/renderUser/fetchBananoMiner.js
+++ b/scripts/components/renderUser/fetchBananoMiner.js
@@ -24,7 +24,7 @@ export const fetchData = async (user) => {
   const bananoData = await Promise.all([
     fetch(`https://bananominer.com/user_name/${user}`),
     fetch(
-      `https://cors-anywhere.herokuapp.com/https://stats.foldingathome.org/api/donor/${user}`,
+      `https://banano-cors-proxy.herokuapp.com/https://stats.foldingathome.org/api/donor/${user}`,
       {
         "Content-Type": "application/json",
       }


### PR DESCRIPTION
Hosted a cors server for banano in heroku and replace the demo cors server to:
https://banano-cors-proxy.herokuapp.com

Also, the current api seems to work so I didn't change it.