### PR TITLE
Fix points cert link

### DIFF
--- a/scripts/components/renderTop/index.js
+++ b/scripts/components/renderTop/index.js
@@ -24,11 +24,12 @@ export const renderTop = () => {
 };
 
 export const bananoMenuCertificates = (data) => {
+  const pointsCertLink = data[1].credit_cert && data[1].credit_cert.replace('&type=score', '')
   if (data[1].credit_cert && data[1].wus_cert)
     document.querySelector(".banano__menu--certificates").innerHTML = `
   <li>
   <a class="banano__top" title="Download Points Certificate from F@H" href="${
-    data[1].credit_cert
+    pointsCertLink
   }">${"Certificate (Points)"}</a></li>
   <li><a class="banano__top" title="Download Work Units Certificate from F@H"  href="${
     data[1].wus_cert


### PR DESCRIPTION
Changes:
- Remove query params for points cert link generated by F@H api. It doesn't recognize `type=score` anymore so invalid type value defaults to the wus link. But removing type param in the link will default it to points cert link.

Fixes: https://github.com/sebrock/bananominer-watch-DEV_TEST/issues/60